### PR TITLE
Add nav-tree; styling updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "kramdown-parser-gfm"
 gem 'jekyll-target-blank'
 gem 'jekyll-sitemap'
 gem 'jekyll-git_metadata'
+
+gem 'jekyll-navigation-tree', :git => 'https://github.com/joshbeard/jekyll-navigation-tree.git', branch: 'customizations'

--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,7 @@ plugins:
   - jekyll-sitemap
   #- jekyll-git_metadata
   - jekyll-sass-converter
+  - jekyll-navigation-tree
 
 target-blank:
   add_css_classes: ext
@@ -81,3 +82,13 @@ defaults:
 album_dir: photos
 album_out_dir: /photos
 album_thumbs_dir: thumbs
+
+nav_tree:
+  excludes:
+    - /sitemap.xml
+    - /photos/*/*jpg.html
+    - /photos/*/*jpeg.html
+    - /photos/*/*.yml
+    - /assets*
+    - /error.html
+    - /sitemap.xml

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,6 +1,6 @@
             <div id="footer">
                 <span class="bottom_text about">
-                    <a href="/site" class="bottom_link">About This Site</a>
+                    <a href="/tree" class="bottom_link">Site Tree</a>
                 </span>
             </div>
         </div>

--- a/_includes/submenu.html
+++ b/_includes/submenu.html
@@ -4,7 +4,7 @@
     <li class="menu-item-{{ loop.index }}">
         {% assign slashed = item.url | append: "/" %}
         {% if (page.url == item.url) or (page.url == slashed) %}
-            {{ item.title }}
+            <span class="sub-menu-current">{{ item.title }}</span>
         {% else %}
             <a href="{{ item.url }}" title="Go to {{ item.title }}">{{ item.title }}</a>
         {% endif %}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -435,6 +435,10 @@ nav#submenu li {
     content: none;
 }
 
+span.sub-menu-current {
+    font-weight: bold;
+}
+
 .about-page nav {
     border-bottom: none;
 }

--- a/resume.md
+++ b/resume.md
@@ -1,0 +1,14 @@
+---
+title: Resume
+meta_title: Resume
+layout: page
+permalink: /resume/
+class: ascii-art
+---
+## My Resume
+
+<!--
+
+This is a placeholder page. My resume is deployed separately.
+
+-->

--- a/tree.md
+++ b/tree.md
@@ -1,0 +1,11 @@
+---
+title: Site Tree
+layout: page
+meta_title: Site Tree
+description: Index of all site pages
+permalink: /tree/
+class: ascii-art
+---
+## Site Tree
+
+{% navigation_tree / %}


### PR DESCRIPTION
* Add a navigation tree using a plugin. This is served at "/tree".
* Add a placeholder 'resume' page for building to generate a menu item in the site tree.
* Update the footer to link to the tree instead of 'About This Site'
* Update the 'About' submenu to style the current page in bold text